### PR TITLE
Feature/backend/#018 user me: 유저 정보 조회

### DIFF
--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
@@ -1,4 +1,36 @@
 package com.kombuchagrande.dailyhabit.controller;
 
+
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import com.kombuchagrande.dailyhabit.mapper.UserMapper;
+import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import com.kombuchagrande.dailyhabit.security.userdetails.CustomUserDetails;
+import com.kombuchagrande.dailyhabit.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/users")
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto> me(@AuthenticationPrincipal CustomUserDetails user) {
+        UserDto userDto = userService.get(user.getUserId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userDto);
+    }
 }

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/users")
+@RequestMapping("/api/users")
 public class UserController {
 
     private final UserService userService;

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/dto/user/UserDto.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/dto/user/UserDto.java
@@ -1,0 +1,9 @@
+package com.kombuchagrande.dailyhabit.dto.user;
+
+public record UserDto(
+        Long id,
+        String nickname,
+        boolean notificationEnabled
+) {
+
+}

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/mapper/UserMapper.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/mapper/UserMapper.java
@@ -1,0 +1,18 @@
+package com.kombuchagrande.dailyhabit.mapper;
+
+
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public UserDto toDto(User user) {
+        return new UserDto(
+                user.getId(),
+                user.getNickname(),
+                user.isNotificationEnabled()
+        );
+    }
+}

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
@@ -1,7 +1,29 @@
 package com.kombuchagrande.dailyhabit.service;
 
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import com.kombuchagrande.dailyhabit.mapper.UserMapper;
+import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    public UserDto get(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException()); //Todo 커스텀 예외처리
+
+        return userMapper.toDto(user);
+    }
+
 }
+

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
@@ -1,0 +1,77 @@
+package com.kombuchagrande.dailyhabit.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.enums.Role;
+import com.kombuchagrande.dailyhabit.security.jwt.JwtService;
+import com.kombuchagrande.dailyhabit.security.jwt.JwtTokenProvider;
+import com.kombuchagrande.dailyhabit.security.jwt.dto.JwtPayloadDto;
+import com.kombuchagrande.dailyhabit.security.userdetails.CustomUserDetails;
+import com.kombuchagrande.dailyhabit.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(controllers = UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    JwtService jwtService;
+
+    @MockitoBean
+    UserService userService;
+
+    private long userId;
+    private CustomUserDetails principal;
+    private UserDto userDto;
+
+    @BeforeEach
+    void setup() {
+        userId = 1L;
+        principal = new CustomUserDetails(
+                new JwtPayloadDto(userId, Role.USER));
+
+        userDto = new UserDto(1L, "nickname1", true);
+    }
+
+    @DisplayName("인증 객체에에 있는 사용자를 조회할 수 있다.")
+    @Test
+    void me_authenticated_returnDto() throws Exception {
+        //given
+
+
+        //when
+        when(userService.get(userId)).thenReturn(userDto);
+
+        //then
+        mockMvc.perform(get("/api/users/me")
+                        .with(user(principal)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(userDto)));
+
+    }
+
+
+
+}

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
@@ -1,0 +1,85 @@
+package com.kombuchagrande.dailyhabit.service;
+
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import com.kombuchagrande.dailyhabit.entity.enums.ProviderType;
+import com.kombuchagrande.dailyhabit.entity.enums.Role;
+import com.kombuchagrande.dailyhabit.mapper.UserMapper;
+import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    UserMapper userMapper;
+
+    @InjectMocks
+    UserService userService;
+
+    private Long userId;
+    private User user;
+    private UserDto userDto;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1L;
+        user = User.builder()
+                .nickname("nick1")
+                .providerType(ProviderType.KAKAO)
+                .role(Role.USER)
+                .providerId("providerId")
+                .notificationEnabled(true)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        userDto = new UserDto(1L, "nick1", true);
+    }
+
+    @DisplayName("유저를 조회할 수 있다.")
+    @Test
+    void getUser() {
+        //given
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userMapper.toDto(user)).thenReturn(userDto);
+
+        //when
+        UserDto result = userService.get(userId);
+
+        //then
+        assertThat(result).isSameAs(userDto);
+        verify(userRepository).findById(userId);
+    }
+
+    @DisplayName("유저가 없다면 예외를 반환한다.")
+    @Test
+    void get_notFound_throws() {
+        //given
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        //when then
+        assertThatThrownBy(() -> userService.get(userId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+
+}


### PR DESCRIPTION
<!-- 

PR 제목 - 브랜치명 : PR에 대한 간단한 요약

-->

## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

- #18
- 사용자 정보 조회 기능 구현하였습니다.

## 설명

<!-- 

- 현재 Pr 설명 

-->

- SecurityContextHolder에 있는 인증객체의 id꺼내 유저를 조회합니다.

## 고민거리 (Optional)

<!-- 

의견 받고싶은 부분 있으면 적어두기
### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->



## 구현사진(Optional)
