### PR TITLE
Feature/backend/#022 user delete: 사용자 논리 삭제

### DIFF
--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/common/validation/NotBlankIfPresent.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/common/validation/NotBlankIfPresent.java
@@ -1,0 +1,17 @@
+package com.kombuchagrande.dailyhabit.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NotBlankIfPresentValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotBlankIfPresent {
+    String message() default "공백 문자열은 허용되지 않습니다.";
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/common/validation/NotBlankIfPresentValidator.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/common/validation/NotBlankIfPresentValidator.java
@@ -1,0 +1,15 @@
+package com.kombuchagrande.dailyhabit.common.validation;
+
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotBlankIfPresentValidator
+        implements ConstraintValidator<NotBlankIfPresent, CharSequence> {
+
+    @Override
+    public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+        return !value.toString().trim().isEmpty();
+    }
+}

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
@@ -2,19 +2,16 @@ package com.kombuchagrande.dailyhabit.controller;
 
 
 import com.kombuchagrande.dailyhabit.dto.user.UserDto;
-import com.kombuchagrande.dailyhabit.entity.User;
-import com.kombuchagrande.dailyhabit.mapper.UserMapper;
-import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import com.kombuchagrande.dailyhabit.dto.user.UserUpdateRequest;
 import com.kombuchagrande.dailyhabit.security.userdetails.CustomUserDetails;
 import com.kombuchagrande.dailyhabit.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @Slf4j
@@ -28,6 +25,18 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserDto> me(@AuthenticationPrincipal CustomUserDetails user) {
         UserDto userDto = userService.get(user.getUserId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userDto);
+    }
+
+    @PatchMapping
+    public ResponseEntity<UserDto> update(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody @Valid UserUpdateRequest request
+            ) {
+        UserDto userDto = userService.update(user.getUserId(), request);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
@@ -1,4 +1,36 @@
 package com.kombuchagrande.dailyhabit.controller;
 
+
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import com.kombuchagrande.dailyhabit.mapper.UserMapper;
+import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import com.kombuchagrande.dailyhabit.security.userdetails.CustomUserDetails;
+import com.kombuchagrande.dailyhabit.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/users")
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto> me(@AuthenticationPrincipal CustomUserDetails user) {
+        UserDto userDto = userService.get(user.getUserId());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userDto);
+    }
 }

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/controller/UserController.java
@@ -35,11 +35,20 @@ public class UserController {
     public ResponseEntity<UserDto> update(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody @Valid UserUpdateRequest request
-            ) {
+    ) {
         UserDto userDto = userService.update(user.getUserId(), request);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(userDto);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.softDelete(userDetails.getUserId());
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
     }
 }

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/dto/user/UserDto.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/dto/user/UserDto.java
@@ -1,0 +1,9 @@
+package com.kombuchagrande.dailyhabit.dto.user;
+
+public record UserDto(
+        Long id,
+        String nickname,
+        boolean notificationEnabled
+) {
+
+}

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/dto/user/UserUpdateRequest.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/dto/user/UserUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.kombuchagrande.dailyhabit.dto.user;
+
+import com.kombuchagrande.dailyhabit.common.validation.NotBlankIfPresent;
+
+public record UserUpdateRequest(
+        @NotBlankIfPresent(message = "닉네임은 공백일 수 없습니다.")
+        String nickname,
+        Boolean notificationEnabled
+) {
+}

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/entity/User.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/entity/User.java
@@ -37,4 +37,8 @@ public class User extends BaseSoftDeletableEntity {
     public void updateNotificationEnabled(Boolean notificationEnabled) {
         this.notificationEnabled = notificationEnabled;
     }
+
+    public void softDelete() {
+        delete();
+    }
 }

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/entity/User.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/entity/User.java
@@ -30,4 +30,11 @@ public class User extends BaseSoftDeletableEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+    public void updateNotificationEnabled(Boolean notificationEnabled) {
+        this.notificationEnabled = notificationEnabled;
+    }
 }

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/mapper/UserMapper.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/mapper/UserMapper.java
@@ -1,0 +1,18 @@
+package com.kombuchagrande.dailyhabit.mapper;
+
+
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public UserDto toDto(User user) {
+        return new UserDto(
+                user.getId(),
+                user.getNickname(),
+                user.isNotificationEnabled()
+        );
+    }
+}

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
@@ -1,7 +1,29 @@
 package com.kombuchagrande.dailyhabit.service;
 
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import com.kombuchagrande.dailyhabit.mapper.UserMapper;
+import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    public UserDto get(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException()); //Todo 커스텀 예외처리
+
+        return userMapper.toDto(user);
+    }
+
 }
+

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
@@ -5,7 +5,6 @@ import com.kombuchagrande.dailyhabit.dto.user.UserUpdateRequest;
 import com.kombuchagrande.dailyhabit.entity.User;
 import com.kombuchagrande.dailyhabit.mapper.UserMapper;
 import com.kombuchagrande.dailyhabit.repository.UserRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,6 +41,16 @@ public class UserService {
         }
 
         return userMapper.toDto(user);
+    }
+
+    @Transactional
+    public void softDelete(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException());//Todo 커스텀 예외처리
+
+        //Todo 추후 복구 로직 생각하기 (로그인 시, 논리 삭제된 계정인지 구분하는 과정 필요)
+        //Todo 특정 시간 이후 DB 에서 스케줄링으로 지우기 (연관관계 생각해서 제거)
+        user.softDelete();
     }
 }
 

--- a/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
+++ b/backend/src/main/java/com/kombuchagrande/dailyhabit/service/UserService.java
@@ -1,12 +1,15 @@
 package com.kombuchagrande.dailyhabit.service;
 
 import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.dto.user.UserUpdateRequest;
 import com.kombuchagrande.dailyhabit.entity.User;
 import com.kombuchagrande.dailyhabit.mapper.UserMapper;
 import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Slf4j
@@ -25,5 +28,20 @@ public class UserService {
         return userMapper.toDto(user);
     }
 
+    @Transactional
+    public UserDto update(Long userId, UserUpdateRequest request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException());//Todo 커스텀 예외처리
+
+        if(request.nickname() != null) {
+            user.updateNickname(request.nickname());
+        }
+        if(request.notificationEnabled() != null) {
+            user.updateNotificationEnabled(request.notificationEnabled());
+        }
+
+        return userMapper.toDto(user);
+    }
 }
 

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
@@ -25,9 +25,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.BDDMockito.given;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -68,11 +68,9 @@ class UserControllerTest {
     @Test
     void me_authenticated_returnDto() throws Exception {
         //given
+        given(userService.get(userId)).willReturn(userDto);
 
-        //when
-        when(userService.get(userId)).thenReturn(userDto);
-
-        //then
+        //when then
         mockMvc.perform(get("/api/users/me")
                         .with(user(principal)))
                 .andExpect(status().isOk())
@@ -80,17 +78,15 @@ class UserControllerTest {
 
     }
 
-    @DisplayName("인증 객체를 가지고 있는 사용자 정보 수정을 할 수 있다.")
+    @DisplayName("인증 객체를 가지고 있는 사용자 정보 수정할 수 있다.")
     @Test
     void update_authenticated_returnDto() throws Exception{
         //given
         UserUpdateRequest request = new UserUpdateRequest("새 닉네임", true);
         UserDto newUserDto = new UserDto(1L, "새 닉네임", true);
+        given(userService.update(userId, request)).willReturn(newUserDto);
 
-        //when
-        when(userService.update(userId, request)).thenReturn(newUserDto);
-
-        //then
+        //when then
         mockMvc.perform(patch("/api/users")
                         .with(csrf())
                         .with(user(principal))
@@ -102,17 +98,15 @@ class UserControllerTest {
         verify(userService).update(eq(userId), any(UserUpdateRequest.class));
     }
 
-    @DisplayName("인증 객체를 가지고 있는 사용자 정보 수정을 할 수 있다.")
+    @DisplayName("인증 객체를 가지고 있는 사용자 정보 수정할 수 있다.")
     @Test
     void update_blankNickname_returnsBadRequest() throws Exception{
         //given
         UserUpdateRequest request = new UserUpdateRequest("", true);
         UserDto newUserDto = new UserDto(1L, "새 닉네임", true);
+        given(userService.update(userId, request)).willReturn(newUserDto);
 
-        //when
-        when(userService.update(userId, request)).thenReturn(newUserDto);
-
-        //then
+        //when then
         mockMvc.perform(patch("/api/users")
                         .with(csrf())
                         .with(user(principal))
@@ -121,6 +115,18 @@ class UserControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(result -> assertThat(result.getResolvedException())
                         .isInstanceOf(MethodArgumentNotValidException.class));
+    }
+
+    @DisplayName("인증 객체를 가지고 있는 사용자를 논리 삭제할 수 있다.")
+    @Test
+    void softDelete_authenticated() throws Exception {
+
+        //when then
+        mockMvc.perform(delete("/api/users")
+                        .with(csrf())
+                        .with(user(principal)))
+                .andExpect(status().isNoContent());
+        verify(userService).softDelete(userId);
     }
 
 

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
@@ -1,0 +1,77 @@
+package com.kombuchagrande.dailyhabit.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.enums.Role;
+import com.kombuchagrande.dailyhabit.security.jwt.JwtService;
+import com.kombuchagrande.dailyhabit.security.jwt.JwtTokenProvider;
+import com.kombuchagrande.dailyhabit.security.jwt.dto.JwtPayloadDto;
+import com.kombuchagrande.dailyhabit.security.userdetails.CustomUserDetails;
+import com.kombuchagrande.dailyhabit.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(controllers = UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    JwtService jwtService;
+
+    @MockitoBean
+    UserService userService;
+
+    private long userId;
+    private CustomUserDetails principal;
+    private UserDto userDto;
+
+    @BeforeEach
+    void setup() {
+        userId = 1L;
+        principal = new CustomUserDetails(
+                new JwtPayloadDto(userId, Role.USER));
+
+        userDto = new UserDto(1L, "nickname1", true);
+    }
+
+    @DisplayName("인증 객체에에 있는 사용자를 조회할 수 있다.")
+    @Test
+    void me_authenticated_returnDto() throws Exception {
+        //given
+
+
+        //when
+        when(userService.get(userId)).thenReturn(userDto);
+
+        //then
+        mockMvc.perform(get("/api/users/me")
+                        .with(user(principal)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(userDto)));
+
+    }
+
+
+
+}

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.kombuchagrande.dailyhabit.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.dto.user.UserUpdateRequest;
 import com.kombuchagrande.dailyhabit.entity.enums.Role;
 import com.kombuchagrande.dailyhabit.security.jwt.JwtService;
 import com.kombuchagrande.dailyhabit.security.jwt.JwtTokenProvider;
@@ -13,10 +14,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
@@ -55,11 +64,10 @@ class UserControllerTest {
         userDto = new UserDto(1L, "nickname1", true);
     }
 
-    @DisplayName("인증 객체에에 있는 사용자를 조회할 수 있다.")
+    @DisplayName("인증 객체를 가지고 있는 사용자를 조회할 수 있다.")
     @Test
     void me_authenticated_returnDto() throws Exception {
         //given
-
 
         //when
         when(userService.get(userId)).thenReturn(userDto);
@@ -72,6 +80,48 @@ class UserControllerTest {
 
     }
 
+    @DisplayName("인증 객체를 가지고 있는 사용자 정보 수정을 할 수 있다.")
+    @Test
+    void update_authenticated_returnDto() throws Exception{
+        //given
+        UserUpdateRequest request = new UserUpdateRequest("새 닉네임", true);
+        UserDto newUserDto = new UserDto(1L, "새 닉네임", true);
+
+        //when
+        when(userService.update(userId, request)).thenReturn(newUserDto);
+
+        //then
+        mockMvc.perform(patch("/api/users")
+                        .with(csrf())
+                        .with(user(principal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(newUserDto)));
+
+        verify(userService).update(eq(userId), any(UserUpdateRequest.class));
+    }
+
+    @DisplayName("인증 객체를 가지고 있는 사용자 정보 수정을 할 수 있다.")
+    @Test
+    void update_blankNickname_returnsBadRequest() throws Exception{
+        //given
+        UserUpdateRequest request = new UserUpdateRequest("", true);
+        UserDto newUserDto = new UserDto(1L, "새 닉네임", true);
+
+        //when
+        when(userService.update(userId, request)).thenReturn(newUserDto);
+
+        //then
+        mockMvc.perform(patch("/api/users")
+                        .with(csrf())
+                        .with(user(principal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(result -> assertThat(result.getResolvedException())
+                        .isInstanceOf(MethodArgumentNotValidException.class));
+    }
 
 
 }

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.kombuchagrande.dailyhabit.service;
 
 import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.dto.user.UserUpdateRequest;
 import com.kombuchagrande.dailyhabit.entity.User;
 import com.kombuchagrande.dailyhabit.entity.enums.ProviderType;
 import com.kombuchagrande.dailyhabit.entity.enums.Role;
@@ -14,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.util.Optional;
 
@@ -65,7 +67,7 @@ class UserServiceTest {
         UserDto result = userService.get(userId);
 
         //then
-        assertThat(result).isSameAs(userDto);
+        assertThat(result).isEqualTo(userDto);
         verify(userRepository).findById(userId);
     }
 
@@ -77,9 +79,38 @@ class UserServiceTest {
 
         //when then
         assertThatThrownBy(() -> userService.get(userId))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class); //Todo 커스텀 예외처리
     }
 
+    @DisplayName("유저 정보를 수정할 수 있다.")
+    @Test
+    void updateUser() {
+        //given
+        UserUpdateRequest request = new UserUpdateRequest("새 닉네임", true);
+        UserDto newUserDto = new UserDto(1L, "새 닉네임", true);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userMapper.toDto(user)).thenReturn(newUserDto);
+
+        //when
+        UserDto result = userService.update(userId, request);
+
+        //then
+        assertThat(result).isEqualTo(newUserDto);
+        assertThat(user.getNickname()).isEqualTo("새 닉네임");
+    }
+
+    @DisplayName("유저 업데이트 시, 유저가 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void update_notFound_throws() {
+        //given
+        UserUpdateRequest request = new UserUpdateRequest("새 닉테임", true);
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        //when then
+        assertThatThrownBy(() -> userService.update(userId, request))
+                .isInstanceOf(IllegalArgumentException.class); //Todo 커스텀 예외처리
+    }
 
 
 }

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
@@ -15,14 +15,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -60,8 +59,8 @@ class UserServiceTest {
     @Test
     void getUser() {
         //given
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userMapper.toDto(user)).thenReturn(userDto);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userMapper.toDto(user)).willReturn(userDto);
 
         //when
         UserDto result = userService.get(userId);
@@ -75,7 +74,7 @@ class UserServiceTest {
     @Test
     void get_notFound_throws() {
         //given
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         //when then
         assertThatThrownBy(() -> userService.get(userId))
@@ -89,8 +88,8 @@ class UserServiceTest {
         UserUpdateRequest request = new UserUpdateRequest("새 닉네임", true);
         UserDto newUserDto = new UserDto(1L, "새 닉네임", true);
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userMapper.toDto(user)).thenReturn(newUserDto);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userMapper.toDto(user)).willReturn(newUserDto);
 
         //when
         UserDto result = userService.update(userId, request);
@@ -105,10 +104,34 @@ class UserServiceTest {
     void update_notFound_throws() {
         //given
         UserUpdateRequest request = new UserUpdateRequest("새 닉테임", true);
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         //when then
         assertThatThrownBy(() -> userService.update(userId, request))
+                .isInstanceOf(IllegalArgumentException.class); //Todo 커스텀 예외처리
+    }
+
+    @DisplayName("사용자의 id로 논리 삭제가 가능하다.")
+    @Test
+    void softSoftDeleteUser() {
+        //given
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        //when
+        userService.softDelete(userId);
+
+        //then
+        assertThat(user.isDeleted()).isTrue();
+    }
+
+    @DisplayName("삭제 시, 유저가 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void softSoftDelete_notFound_throws() {
+        //given
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        //when then
+        assertThatThrownBy(() -> userService.softDelete(userId))
                 .isInstanceOf(IllegalArgumentException.class); //Todo 커스텀 예외처리
     }
 

--- a/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
+++ b/backend/src/test/java/com/kombuchagrande/dailyhabit/service/UserServiceTest.java
@@ -1,0 +1,85 @@
+package com.kombuchagrande.dailyhabit.service;
+
+import com.kombuchagrande.dailyhabit.dto.user.UserDto;
+import com.kombuchagrande.dailyhabit.entity.User;
+import com.kombuchagrande.dailyhabit.entity.enums.ProviderType;
+import com.kombuchagrande.dailyhabit.entity.enums.Role;
+import com.kombuchagrande.dailyhabit.mapper.UserMapper;
+import com.kombuchagrande.dailyhabit.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    UserMapper userMapper;
+
+    @InjectMocks
+    UserService userService;
+
+    private Long userId;
+    private User user;
+    private UserDto userDto;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1L;
+        user = User.builder()
+                .nickname("nick1")
+                .providerType(ProviderType.KAKAO)
+                .role(Role.USER)
+                .providerId("providerId")
+                .notificationEnabled(true)
+                .build();
+
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        userDto = new UserDto(1L, "nick1", true);
+    }
+
+    @DisplayName("유저를 조회할 수 있다.")
+    @Test
+    void getUser() {
+        //given
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userMapper.toDto(user)).thenReturn(userDto);
+
+        //when
+        UserDto result = userService.get(userId);
+
+        //then
+        assertThat(result).isSameAs(userDto);
+        verify(userRepository).findById(userId);
+    }
+
+    @DisplayName("유저가 없다면 예외를 반환한다.")
+    @Test
+    void get_notFound_throws() {
+        //given
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        //when then
+        assertThatThrownBy(() -> userService.get(userId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+
+}


### PR DESCRIPTION
<!-- 

PR 제목 - 브랜치명 : PR에 대한 간단한 요약

-->

## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->
- #22 
- 사용자 논리 삭제 구현하였습니다.

## 설명

<!-- 

- 현재 Pr 설명 

-->

- [DELETE] /api/users/delete 엔드포인트 구현
- 컨트롤러, 서비스 단위테스트 추가

</br>

- 추후 배치로 특정 시간이 지난 유저는 자동 물리 삭제 되도록 구현 예정입니다.
- 사용자가 로그인할 때, 논리 삭제가 된 사용자인지 구분이 가능하게 값을 줄 필요가 있을 것 같습니다. (복구 여부 확인)

## 고민거리 (Optional)

<!-- 

의견 받고싶은 부분 있으면 적어두기
### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

## 구현사진(Optional)
